### PR TITLE
Update SQS queue ARN for Logging IAM policy

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -25,7 +25,7 @@ module "vpc_dr" {
 }
 
 module "rms_main" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.1"
 
   # Required parameters
   name    = "Test-RMS"
@@ -45,7 +45,7 @@ module "rms_main" {
 }
 
 module "rms_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.1"
 
   providers = {
     aws = "aws.oregon"

--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,7 @@ module "logging_role" {
 
   policy_vars = {
     cloudtrail_bucket = "${data.aws_canonical_user_id.current.display_name}-logs"
-    sqs_queue_arn     = "arn:aws:sqs:us-west-2:794790922771:rms-stack-ALSQSQueue-130WSCL28TCBR"
+    sqs_queue_arn     = "${element(concat(aws_sqs_queue.altm_queue.*.arn, list("")),0)}"
   }
 }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -19,6 +19,19 @@ module "test_rms" {
   build_state             = "Test"
 }
 
+module "test_rms_no_customer_id" {
+  source = "../../module"
+
+  # Required parameters
+  name        = "Test-RMS2"
+  subnets     = "${module.vpc.private_subnets}"
+  build_state = "Test"
+}
+
 output "RMS_Deployment_Info" {
   value = "${module.test_rms.deployment_details}"
+}
+
+output "RMS_Deployment_Info_No_Customer_ID" {
+  value = "${module.test_rms_no_customer_id.deployment_details}"
 }


### PR DESCRIPTION
- Updates Logging IAM policy from hard coded SQS queue ARN to created queue ARN
- Updates Examples to latest pinned version
- Updates test to include secondary buildof RMS module (One without customer ID defined)

fixes rackspace-infrastructure-automation/aws-terraform-internal#138