### PR TITLE
Explicitly use us-west-2 for canonical id lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module deploys the required infrastructure for an RMS managed Alert Logic d
 
 ```
 module "rms_main" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.0.1"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
 
  name    = "Test-RMS"
  subnets = "${module.vpc.private_subnets}"

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -25,7 +25,7 @@ module "vpc_dr" {
 }
 
 module "rms_main" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
 
   # Required parameters
   name    = "Test-RMS"
@@ -45,7 +45,7 @@ module "rms_main" {
 }
 
 module "rms_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
 
   providers = {
     aws = "aws.oregon"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  *
  *```
  *module "rms_main" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.0.1"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
  *
  *  name    = "Test-RMS"
  *  subnets = "${module.vpc.private_subnets}"
@@ -29,7 +29,11 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-data "aws_canonical_user_id" "current" {}
+data "aws_canonical_user_id" "current" {
+  # Explicitly setting this call to the us-west-2 region due to existing terraform bug
+  # at https://github.com/terraform-providers/terraform-provider-aws/issues/6762
+  provider = "aws.rms_oregon"
+}
 
 data "aws_subnet" "selected" {
   id = "${element(var.subnets, 0)}"


### PR DESCRIPTION
Fixes rackspace-infrastructure-automation/aws-terraform-internal#182

This change forces the aws_canonical_user_id data resource to use the us-west-2 region, which is not affected by the terraform bug.