### PR TITLE
Allow overriding the calculated bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module deploys the required infrastructure for an RMS managed Alert Logic d
 
 ```
 module "rms_main" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.3"
 
  name    = "Test-RMS"
  subnets = "${module.vpc.private_subnets}"
@@ -27,6 +27,7 @@ Full working references are available at [examples](examples)
 | alert_logic_data_center | Alert Logic Data Center where logs will be shipped. | string | `US` | no |
 | az_count | Number of Availability Zones. For environments where only Log ingestion is required, please select 0 | string | `2` | no |
 | build_state | Allowed values 'Deploy' or 'Test'.  Select 'Deploy' unless the stack is being built for testing in an account without access to the Alert Logic AMIs. | string | `Deploy` | no |
+| cloudtrail_bucket | The desired cloudtrail log bucket to monitor.  In most cases, the correct bucket will be determined via the canonical user id display name, but if a nonstand value is used, or a custom bucket name is needed, the full bucket name can be provided here. | string | `` | no |
 | environment | Application environment for which this infrastructure is being created. e.g. Development/Production. | string | `Production` | no |
 | instance_type | The instance type to use for the Alert Logic appliances.  Defaults to c5.large | string | `c5.large` | no |
 | key_pair | Name of an existing EC2 KeyPair to enable SSH access to the instances. | string | `` | no |

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -25,7 +25,7 @@ module "vpc_dr" {
 }
 
 module "rms_main" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.3"
 
   # Required parameters
   name    = "Test-RMS"
@@ -45,7 +45,7 @@ module "rms_main" {
 }
 
 module "rms_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.3"
 
   providers = {
     aws = "aws.oregon"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  *
  *```
  *module "rms_main" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.2"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.1.3"
  *
  *  name    = "Test-RMS"
  *  subnets = "${module.vpc.private_subnets}"
@@ -234,8 +234,12 @@ module "logging_role" {
   policy_file        = "${"${path.module}/iam_policies/logging_role_policy.json"}"
 
   policy_vars = {
-    cloudtrail_bucket = "${data.aws_canonical_user_id.current.display_name}-logs"
-    sqs_queue_arn     = "${element(concat(aws_sqs_queue.altm_queue.*.arn, list("")),0)}"
+    cloudtrail_bucket = "${var.cloudtrail_bucket != "" ?
+                           var.cloudtrail_bucket :
+                           "${data.aws_canonical_user_id.current.display_name}-logs"
+                         }"
+
+    sqs_queue_arn = "${element(concat(aws_sqs_queue.altm_queue.*.arn, list("")),0)}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "az_count" {
   default     = 2
 }
 
+variable "cloudtrail_bucket" {
+  description = "The desired cloudtrail log bucket to monitor.  In most cases, the correct bucket will be determined via the canonical user id display name, but if a nonstand value is used, or a custom bucket name is needed, the full bucket name can be provided here."
+  type        = "string"
+  default     = ""
+}
+
 variable "build_state" {
   description = "Allowed values 'Deploy' or 'Test'.  Select 'Deploy' unless the stack is being built for testing in an account without access to the Alert Logic AMIs."
   type        = "string"


### PR DESCRIPTION
Adds an optional `cloudtrail_bucket` variable.  This variable allows overriding the bucket name determined from the aws_canonical_user_id field, and allows a custom bucket name to be set instead.  This can be used in cases where the Cloudtrail is configured with a non-standard bucket, or a non-standard display name is set for the canonical user id.