### PR TITLE
Update inline IAM policy for EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to create several of the resources.  The dependancies for these resources only e
 
 ```HCL
 module "rms_main" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.2"
 
   alert_logic_customer_id = "123456789"
   name                    = "Test-RMS"

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -30,7 +30,7 @@ module "vpc_dr" {
 }
 
 module "rms_main" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.2"
 
   # alert_logic_customer_id required for first deployment in an account
   alert_logic_customer_id = "123456789"
@@ -54,7 +54,7 @@ module "rms_main" {
 }
 
 module "rms_dr" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.2"
 
   # Required parameters
   name    = "Test-RMS-DR"

--- a/iam_policies/appliance_role_policy.json
+++ b/iam_policies/appliance_role_policy.json
@@ -1,21 +1,48 @@
 {
   "Statement": [
-    {"Action": ["cloudformation:Describe*"],
-      "Resource": "*", "Effect": "Allow"},
-    {"Action": ["ssm:CreateAssociation",
-          "ssm:DescribeInstanceInformation"],
-      "Resource": "*", "Effect": "Allow"},
-    {"Action": ["cloudwatch:PutMetricData",
-          "cloudwatch:GetMetricStatistics",
-          "cloudwatch:ListMetrics",
-          "logs:CreateLogStream",
-          "ec2:DescribeTags",
-          "logs:DescribeLogStreams",
-          "logs:CreateLogGroup",
-          "logs:PutLogEvents",
-          "ssm:GetParameter"],
-      "Resource": "*", "Effect": "Allow"},
-    {"Action": ["ec2:DescribeTags"],
-      "Resource": "*", "Effect": "Allow"}
+    {
+      "Action": [
+        "cloudformation:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ssm:CreateAssociation",
+        "ssm:DescribeInstanceInformation",
+        "ssm:GetParameter"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:PutMetricData",
+        "ec2:DescribeTags",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetBucketLocation",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::rackspace-*/*"
+    }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@
  *
  * ```HCL
  * module "rms_main" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.0"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-rms//?ref=v0.12.2"
  *
  *   alert_logic_customer_id = "123456789"
  *   name                    = "Test-RMS"
@@ -384,9 +384,14 @@ module "instance_role" {
 
   assume_role_policy = data.aws_iam_policy_document.ec2_assume_role_policy.json
   name               = "${var.name}-InstanceRole"
-  policy_arns        = ["arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"]
   policy_file        = "${path.module}/iam_policies/appliance_role_policy.json"
   policy_vars        = {}
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+    "arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess",
+  ]
 }
 
 resource "aws_iam_instance_profile" "instance_profile" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-962](https://jira.rax.io/browse/MPCSUPENG-962)
 - [MPCSUPENG-913](https://jira.rax.io/browse/MPCSUPENG-913)

##### Summary of change(s):
Updates default inline IAM policy for EC2 instances to only allow access to buckets beginning with `rackspace-`. This will allow access to predetermined S3 files, and if additional S3 locations are required, a managed policy can be assigned to the instances IAM role via existing parameters.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
Yes. The change does destroy the policy attachment for the deprecated `AmazonEC2RoleforSSM` IAM policy, and replaces it with attachments for the three new AWS managed policies. 

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
No variable or output changes.  Version pinning in readme and examples updated.
##### Do examples need to be updated based on changes?
Version pinning in readme and examples updated.
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
