### PR TITLE
Update CW Alarm pinnings to v0.12.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 - status\_check\_failed\_instance\_alarm\_reboot
 - status\_check\_failed\_system\_alarm\_recover
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.7.0 |
+
 ## Providers
 
 | Name | Version |
@@ -45,10 +52,41 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | local | n/a |
 | null | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| cross_account_role | ./iam_role |  |
+| instance_role | ./iam_role |  |
+| logging_role | ./iam_role |  |
+| status_check_failed_instance_alarm_ticket | git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6 |  |
+| status_check_failed_system_alarm_ticket | git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/caller_identity) |
+| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/canonical_user_id) |
+| [aws_cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/cloudwatch_metric_alarm) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_instance_profile) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/iam_policy) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/iam_policy_document) |
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/instance) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/region) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/security_group) |
+| [aws_sns_topic_subscription](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/sns_topic_subscription) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/sqs_queue) |
+| [aws_sqs_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/sqs_queue_policy) |
+| [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/subnet) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/data-sources/vpc) |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alert\_logic\_customer\_id | The Alert Logic Customer ID, provided by RMS. A numeric string between 3 and 12 characters in length. Omit if this is not the first RMS deployment under this account. | `string` | `""` | no |
 | alert\_logic\_data\_center | Alert Logic Data Center where logs will be shipped. | `string` | `"US"` | no |
 | az\_count | Number of Availability Zones. For environments where only Log ingestion is required, please select 0 | `number` | `2` | no |
@@ -76,4 +114,3 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | logging\_role\_arn | Logging IAM Role ARN |
 | managed\_instance\_policy\_arn | RMS Managed instance policy ARN |
 | sqs\_queue\_name | Name of the Alert Logic SQS queue |
-

--- a/main.tf
+++ b/main.tf
@@ -427,7 +427,7 @@ resource "aws_instance" "threat_manager" {
 }
 
 module "status_check_failed_system_alarm_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6"
 
   alarm_count              = var.az_count
   alarm_description        = "Status checks have failed for system, generating ticket."
@@ -448,7 +448,7 @@ module "status_check_failed_system_alarm_ticket" {
 }
 
 module "status_check_failed_instance_alarm_ticket" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.6"
 
   alarm_count              = var.az_count
   alarm_description        = "Status checks have failed for instance, generating ticket."


### PR DESCRIPTION
##### Corresponding Issue(s):
[MPCSUPENG-2116](https://jira.rax.io/browse/MPCSUPENG-2116)

##### Summary of change(s):
Updates pinning of CloudWatch alarm module to v0.12.6 to correct validation errors

##### Reason for Change(s):

- Corrects validation errors introduced due to recent AWS provider updates

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
Yes, updates to CW Alarm module
##### If input variables or output variables have changed or has been added, have you updated the README?
NA
##### Do examples need to be updated based on changes?
NA
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
